### PR TITLE
Large payloads

### DIFF
--- a/source/droid/gateway/compression.d
+++ b/source/droid/gateway/compression.d
@@ -1,0 +1,37 @@
+module droid.gateway.compression;
+
+import droid.exception;
+import std.zlib,
+       std.stdio,
+       std.conv : to;
+
+enum CompressionType : string {
+    NONE        = "",
+    ZLIB        = "zlib",
+    ZLIB_STREAM = "zlib-stream"
+}
+class Decompressor {
+    string read(ubyte[] data) {
+        throw new DroidException("Compression type not supported!");
+    }
+}
+
+class ZLibStream : Decompressor {
+    const ulong[] ZLIB_SUFFIX = [0x0, 0x0, 0xFF, 0xFF];
+    UnCompress decompressor;
+
+    this() {
+        decompressor = new UnCompress(HeaderFormat.deflate);
+    }
+
+    override string read(ubyte[] data) {
+        if (data[$-4..$] != ZLIB_SUFFIX) {
+            throw new DroidException("ZLib-Stream compression enabled but invalid data was recieved!");
+        }
+
+        string decompressed = to!string(decompressor.uncompress(data));
+        decompressor.flush();
+
+        return decompressed;
+    }
+}

--- a/source/droid/gateway/compression.d
+++ b/source/droid/gateway/compression.d
@@ -17,20 +17,31 @@ class Decompressor {
 }
 
 class ZLibStream : Decompressor {
-    const ulong[] ZLIB_SUFFIX = [0x0, 0x0, 0xFF, 0xFF];
+    const ubyte[] ZLIB_SUFFIX = [0x0, 0x0, 0xFF, 0xFF];
     UnCompress decompressor;
+
+    ubyte[] buffer;
 
     this() {
         decompressor = new UnCompress(HeaderFormat.deflate);
     }
 
+    /*
+     * Reads a zlib stream from the websocket
+     * This will append the data to a buffer,
+     * returning nothing if the data is not a full zlib frame
+     * otherwise, returning the decompressed string.
+     */
     override string read(ubyte[] data) {
+        buffer ~= data;
+
         if (data[$-4..$] != ZLIB_SUFFIX) {
-            throw new DroidException("ZLib-Stream compression enabled but invalid data was recieved!");
+            return "";
         }
 
-        string decompressed = to!string(decompressor.uncompress(data));
+        string decompressed = to!string(decompressor.uncompress(buffer));
         decompressor.flush();
+        buffer = null;
 
         return decompressed;
     }

--- a/source/droid/gateway/compression.d
+++ b/source/droid/gateway/compression.d
@@ -10,9 +10,16 @@ enum CompressionType : string {
     ZLIB        = "zlib",
     ZLIB_STREAM = "zlib-stream"
 }
+
 class Decompressor {
     string read(ubyte[] data) {
         throw new DroidException("Compression type not supported!");
+    }
+}
+
+class ZLib : Decompressor {
+    override string read(ubyte[] data) {
+        return to!string(new UnCompress(HeaderFormat.deflate).uncompress(data));
     }
 }
 

--- a/source/droid/gateway/gateway.d
+++ b/source/droid/gateway/gateway.d
@@ -148,10 +148,6 @@ final class Gateway
         return true;
     }
 
-    public void kys() {
-        ws_.close();
-    }
-
     private void handleEvents()
     {
         assert(ws_ && ws_.connected);
@@ -159,9 +155,9 @@ final class Gateway
         while (ws_.waitForData()) {
             auto data = "";
 
-            if (decompressor) {
+            if (decompressor)
                 data = decompressor.read(ws_.receiveBinary());
-            } else
+            else
                 data = ws_.receiveText();
 
             const packet = parseMessage(data);

--- a/source/droid/gateway/gateway.d
+++ b/source/droid/gateway/gateway.d
@@ -160,6 +160,9 @@ final class Gateway
             else
                 data = ws_.receiveText();
 
+            // The data isn't complete (not a full zlib message, or something borked)
+            if (data == "") return;
+
             const packet = parseMessage(data);
 
             auto opcodeHandler = packet.opcode in OPCODE_MAPPING;

--- a/source/droid/gateway/package.d
+++ b/source/droid/gateway/package.d
@@ -4,4 +4,5 @@ public {
     import droid.gateway.opcode;
     import droid.gateway.packet;
     import droid.gateway.gateway;
+    import droid.gateway.compression;
 }


### PR DESCRIPTION
Adds support for compressed payloads via identify.
This does a (maybe eh) check to see if it's binary and decompress, if not, use text.

Based off of #9 

With the closing of 9, and this one, #4 will be complete.